### PR TITLE
Exclude bcel from dependency tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.compiler.target>8</maven.compiler.target>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
     <pulsar.version>2.10.0</pulsar.version>
-    <qpid.version>8.0.0</qpid.version>
+    <qpid.version>8.0.6</qpid.version>
     <failsafe.version>2.4.2</failsafe.version>
     <curator.version>5.1.0</curator.version>
     <junit.version>5.7.1</junit.version>
@@ -91,6 +91,12 @@
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-broker-core</artifactId>
         <version>${qpid.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.bcel</groupId>
+            <artifactId>bcel</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>


### PR DESCRIPTION
* bcel is only used in qpid-broker-core by LDAPSSLSocketFactoryGenerator which we don't use
* the bcel version pulled has a vulnerability