### PR TITLE
Update dependencies to fix CVE-2024-7254, CVE-2024-36114 & CVE-2024-53990

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/nar-tests/pom.xml
+++ b/nar-tests/pom.xml
@@ -77,10 +77,10 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <echo>copy proxy protocol handler</echo>
                 <copy file="${basedir}/../starlight-rabbitmq/target/starlight-rabbitmq-${project.version}.nar" tofile="${project.build.outputDirectory}/test-protocol-handler.nar"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,6 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-broker</artifactId>
         <version>${pulsar.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,20 +74,26 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
         <version>${aircompressor.version}</version>
+        <scope>runtime</scope>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
+        <scope>runtime</scope>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${asynchttpclient.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
     <junit.version>5.7.1</junit.version>
     <surefire.version>3.0.0-M9</surefire.version>
     <rabbitmqclient.version>5.12.0</rabbitmqclient.version>
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
+    <aircompressor.version>0.27</aircompressor.version>
+    <protobuf.version>3.25.5</protobuf.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -64,6 +67,27 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-broker</artifactId>
         <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>${aircompressor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>


### PR DESCRIPTION
asynchttpclient 2.12.1 contains CVE-2024-53990 vulnerability and its fixed in 2.12.4.
aircompressor 0.21 contains CVE-2024-36114 vulnerability and its fixed in 0.27
protobuf-java 3.19.6 contains CVE-2024-7254 vulnerability and its fixed in contains 3.25.5