### PR TITLE
Update dependencies to fix CVE-2024-7254, CVE-2024-36114 & CVE-2024-53990

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -12,12 +12,15 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.9
+        
+      - name: Check Maven version
+        run: mvn -v
 
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -13,6 +13,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+      
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
 
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/nar-tests/pom.xml
+++ b/nar-tests/pom.xml
@@ -79,7 +79,7 @@
             <configuration>
               <target>
                 <echo>copy proxy protocol handler</echo>
-                <copy file="${basedir}/../starlight-rabbitmq/target/starlight-rabbitmq-${project.version}.nar" tofile="${project.build.outputDirectory}/test-protocol-handler.nar" />
+                <copy file="${basedir}/../starlight-rabbitmq/target/starlight-rabbitmq-${project.version}.nar" tofile="${project.build.outputDirectory}/test-protocol-handler.nar"/>
               </target>
             </configuration>
           </execution>

--- a/nar-tests/pom.xml
+++ b/nar-tests/pom.xml
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>pulsar</artifactId>
+      <version>1.20.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nar-tests/src/test/java/com/datastax/oss/starlight/rabbitmqnartests/DockerTest.java
+++ b/nar-tests/src/test/java/com/datastax/oss/starlight/rabbitmqnartests/DockerTest.java
@@ -54,6 +54,7 @@ public class DockerTest {
   private static final String IMAGE_PULSAR40 = "apachepulsar/pulsar:4.0.4";
 
   @ParameterizedTest
+  // s4r built against pulsar 4.0 may not be compatible with older docker images
   @ValueSource(strings = {IMAGE_PULSAR40, IMAGE_LUNASTREAMING40})
   public void test(String image) throws Exception {
     // create a docker network

--- a/nar-tests/src/test/java/com/datastax/oss/starlight/rabbitmqnartests/DockerTest.java
+++ b/nar-tests/src/test/java/com/datastax/oss/starlight/rabbitmqnartests/DockerTest.java
@@ -50,12 +50,11 @@ import org.testcontainers.containers.Network;
 
 public class DockerTest {
 
-  private static final String IMAGE_LUNASTREAMING210 = "datastax/lunastreaming:2.10_2.9";
-  private static final String IMAGE_PULSAR210 = "apachepulsar/pulsar:2.10.2";
-  private static final String IMAGE_PULSAR211 = "apachepulsar/pulsar:2.11.0";
+  private static final String IMAGE_LUNASTREAMING40 = "datastax/lunastreaming:4.0_3.2";
+  private static final String IMAGE_PULSAR40 = "apachepulsar/pulsar:4.0.4";
 
   @ParameterizedTest
-  @ValueSource(strings = {IMAGE_PULSAR211, IMAGE_PULSAR210, IMAGE_LUNASTREAMING210})
+  @ValueSource(strings = {IMAGE_PULSAR40, IMAGE_LUNASTREAMING40})
   public void test(String image) throws Exception {
     // create a docker network
     try (Network network = Network.newNetwork();

--- a/nar-tests/src/test/java/com/datastax/oss/starlight/rabbitmqnartests/PulsarContainer.java
+++ b/nar-tests/src/test/java/com/datastax/oss/starlight/rabbitmqnartests/PulsarContainer.java
@@ -65,7 +65,7 @@ public class PulsarContainer implements AutoCloseable {
                 "/pulsar/protocols/starlight-for-rabbitmq.nar",
                 BindMode.READ_ONLY)
             .withClasspathResourceMapping(
-                "standalone_with_s4r.conf", "/pulsar/conf/standalone.conf", BindMode.READ_ONLY)
+                "standalone_with_s4r.conf", "/pulsar/conf/standalone.conf", BindMode.READ_WRITE)
             .withLogConsumer(
                 (f) -> {
                   String text = f.getUtf8String().trim();

--- a/nar-tests/src/test/resources/proxy_with_s4r.conf
+++ b/nar-tests/src/test/resources/proxy_with_s4r.conf
@@ -223,7 +223,7 @@ tokenAudience=
 webSocketServiceEnabled=false
 
 # Name of the cluster to which this broker belongs to
-clusterName=
+clusterName=standalone
 
 ### --- Deprecated config variables --- ###
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
     <junit.version>5.6.2</junit.version>
     <surefire.version>3.0.0-M9</surefire.version>
     <rabbitmqclient.version>5.12.0</rabbitmqclient.version>
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
+    <aircompressor.version>0.27</aircompressor.version>
+    <protobuf.version>3.25.5</protobuf.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -64,6 +67,27 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-broker</artifactId>
         <version>${pulsar.version}</version>
+      </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>${aircompressor.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>


### PR DESCRIPTION
### Motivation
asynchttpclient 2.12.1 contains https://github.com/advisories/GHSA-mfj5-cf8g-g2fv vulnerability and its fixed in 2.12.4.
aircompressor 0.21 contains https://github.com/advisories/GHSA-973x-65j7-xcf4 vulnerability and its fixed in 0.27
protobuf-java 3.19.6 contains https://github.com/advisories/GHSA-735f-pc8j-v9w8 vulnerability and its fixed in contains 3.25.5

Jira Link: https://datastax.jira.com/browse/STREAM-613

(cherry picked from commits https://github.com/datastax/starlight-for-rabbitmq/commit/080b8c4a737c31474ae7695e19a57ad6fd8ba502)